### PR TITLE
Fix for finding all templates within a nested directory structure.

### DIFF
--- a/src/tasks/Build.js
+++ b/src/tasks/Build.js
@@ -54,7 +54,7 @@ class BuildTask extends Task {
 		fs.readdirSync(dir).forEach((file) => {
 			const filename = path.join(dir, file);
 			if (fs.statSync(filename).isDirectory()) {
-				newlist = this.walkTemplates(filename, list);
+				newlist = [...newlist, ...this.walkTemplates(filename, list)];
 			} else {
 				newlist.push(filename);
 			}


### PR DESCRIPTION
When scanning a directory this change keeps the existing list rather than overwriting it.