### PR TITLE
explicit sort so we can deliberately override definitions

### DIFF
--- a/src/tasks/Build.js
+++ b/src/tasks/Build.js
@@ -59,7 +59,7 @@ class BuildTask extends Task {
 	walkTemplates(dir, list) {
 		let newlist = [...list];
 
-		fs.readdirSync(dir).forEach((file) => {
+		fs.readdirSync(dir).sort().forEach((file) => {
 			const filename = path.join(dir, file);
 			if (fs.statSync(filename).isDirectory()) {
 				newlist = [...newlist, ...this.walkTemplates(filename, list)];


### PR DESCRIPTION
Small change to sort input files. Knowing the order in which files are processed makes it possible to deliberately override resources (e.g. using numbered file names, rc.d style).