### PR TITLE
Add ability to skip validation process inside build task

### DIFF
--- a/bin/cfpack.js
+++ b/bin/cfpack.js
@@ -57,7 +57,12 @@ async function bootstrap() {
 	yargs.usage('Usage: cfpack <command>');
 
 	yargs.command('init', 'Initializes cfpack config in the current directory.', {}, dispatch);
-	yargs.command('build', 'Assembles templates into one CloudFormation template.', {}, dispatch);
+	yargs.command(
+		'build',
+		'Assembles templates into one CloudFormation template.',
+		(innerYargs) => innerYargs.option('force', { describe: 'Skips validation process', type: 'boolean' }),
+		dispatch,
+	);
 	yargs.command('deploy', 'Assembles and deploys CloudFormation template.', {}, dispatch);
 	yargs.command('artifacts', 'Uploads artifacts to s3 buckets.', {}, dispatch);
 	yargs.command('delete', 'Deletes CloudFormation stack.', {}, dispatch);

--- a/src/tasks/Build.js
+++ b/src/tasks/Build.js
@@ -28,12 +28,19 @@ class BuildTask extends Task {
 		this.log.info('├─ Processing found templates...');
 		this.processTemplates();
 
-		this.log.info('├─ Validating final template...');
-		this.validateFinalTemplate(() => {
+		const saveTemplate = () => {
 			this.saveFinalTemplate();
 			this.log.info(`└─ Final template: ${chalk.magenta(this.output.templateFile)}\n`);
 			next(this.output);
-		});
+		};
+
+		if (this.options.force) {
+			this.log.info('├─ Skipping validation process...');
+			saveTemplate();
+		} else {
+			this.log.info('├─ Validating final template...');
+			this.validateFinalTemplate(saveTemplate);
+		}
 	}
 
 	findTemplates() {


### PR DESCRIPTION
Sometimes when final template is huge, validation process throws error (`Member must have length less than or equal to 51200`). This is because aws cli is not able to handle it and prefers uploading template to S3, then validate. To be able to generate final form of template one of the available option is to skip validation. So this is what I did in PR.