### PR TITLE
Enabling uploading of the template to S3

### DIFF
--- a/src/tasks/Build.js
+++ b/src/tasks/Build.js
@@ -34,7 +34,7 @@ class BuildTask extends Task {
 			next(this.output);
 		};
 
-		if (this.options.validate === false) {
+		if (this.options.validate === false || this.options.s3Bucket) {
 			this.log.info('├─ Skipping validation process...');
 			saveTemplate();
 		} else {
@@ -44,10 +44,13 @@ class BuildTask extends Task {
 	}
 
 	findTemplates() {
-		const { entry, config } = this.options;
-		const entryPath = path.isAbsolute(entry)
-			? entry
-			: path.resolve(path.dirname(config), entry);
+		const {
+			entry,
+			config
+		} = this.options;
+		const entryPath = path.isAbsolute(entry) ?
+			entry :
+			path.resolve(path.dirname(config), entry);
 
 		if (!fs.existsSync(entryPath)) {
 			this.log.error('└─ The entry folder is not found.');
@@ -120,9 +123,11 @@ class BuildTask extends Task {
 		const content = fs.readFileSync(file, 'utf8');
 
 		try {
-			return content.trim(0).charAt(0) === '{'
-				? JSON.parse(content)
-				: yaml.safeLoad(content, { schema: intrinsicFunctions });
+			return content.trim(0).charAt(0) === '{' ?
+				JSON.parse(content) :
+				yaml.safeLoad(content, {
+					schema: intrinsicFunctions
+				});
 		} catch (e) {
 			this.lastError = e;
 		}
@@ -131,7 +136,9 @@ class BuildTask extends Task {
 	}
 
 	validateFinalTemplate(callback) {
-		const { stack } = this.options;
+		const {
+			stack
+		} = this.options;
 		const cloudformation = new AWS.CloudFormation({
 			apiVersion: '2010-05-15',
 			region: stack.region,
@@ -144,7 +151,9 @@ class BuildTask extends Task {
 			TemplateBody = JSON.stringify(this.output.template);
 		}
 
-		cloudformation.validateTemplate({ TemplateBody }, (err) => {
+		cloudformation.validateTemplate({
+			TemplateBody
+		}, (err) => {
 			if (err) {
 				this.log.error(`├─ ${err.message}`, false);
 				this.log.error(`└─ RequestId: ${chalk.magenta(err.requestId)}`, false);
@@ -157,7 +166,10 @@ class BuildTask extends Task {
 	}
 
 	saveFinalTemplate() {
-		const { output, config } = this.options;
+		const {
+			output,
+			config
+		} = this.options;
 
 		let filename = output;
 		if (!filename) {
@@ -166,12 +178,14 @@ class BuildTask extends Task {
 			filename = path.join(folder, 'template.json');
 		}
 
-		filename = path.isAbsolute(filename)
-			? filename
-			: path.resolve(path.dirname(config), filename);
+		filename = path.isAbsolute(filename) ?
+			filename :
+			path.resolve(path.dirname(config), filename);
 
 		const data = JSON.stringify(this.output.template, '', 4);
-		fs.writeFileSync(filename, data, { encoding: 'utf8' });
+		fs.writeFileSync(filename, data, {
+			encoding: 'utf8'
+		});
 		this.output.templateFile = filename;
 	}
 

--- a/src/tasks/Init.js
+++ b/src/tasks/Init.js
@@ -25,7 +25,9 @@ class Init extends Task {
 		}
 
 		const options = {
-			interactive: { default: true },
+			interactive: {
+				default: true
+			},
 			stackName: {
 				type: 'input',
 				default: defaults.stackname,
@@ -64,7 +66,9 @@ class Init extends Task {
 
 	static saveConfig(results) {
 		const filename = Init.getConfigFilename();
-		const stream = fs.createWriteStream(filename, { encoding: 'utf8' });
+		const stream = fs.createWriteStream(filename, {
+			encoding: 'utf8'
+		});
 
 		stream.write(`module.exports = {
 	entry: ${JSON.stringify(results.entryFolder)}, // folder with templates
@@ -74,6 +78,8 @@ class Init extends Task {
 	stack: {
 		name: ${JSON.stringify(results.stackName)}, // stack name
 		region: ${JSON.stringify(results.stackRegion)}, // stack region
+		/* uncomment if you want to upload the template file to S3 */
+		// s3Bucket: "your-s3-bucket",
 		params: {
 			/**
 			 * Extra parameters that can be used by API


### PR DESCRIPTION
Allow entry of an S3 bucket so that the deployment process can upload.  I didn't add it to the Build.js file, but instead have it skipping validation if there is an S3 bucket - I just wanted something that will work with my large template set.